### PR TITLE
Apply, create and delete multiple documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: $(OUTPUT)
 	go test ./internal/...
 
 lint: $(OUTPUT)
-	gometalinter run
+	golangci-lint run
 
 .PHONY: build clean test lint
 

--- a/cmd/gitstrap/cmd_apply.go
+++ b/cmd/gitstrap/cmd_apply.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/g4s8/gitstrap/internal/gitstrap"
 	"github.com/g4s8/gitstrap/internal/spec"
 	"github.com/g4s8/gitstrap/internal/view"
@@ -10,9 +8,12 @@ import (
 )
 
 var applyCommand = &cli.Command{
-	Name:   "apply",
-	Usage:  "Apply new specficiation",
-	Action: cmdApply,
+	Name:  "apply",
+	Usage: "Apply new specficiation",
+	Action: cmdForEachModel(func(g *gitstrap.Gitstrap, m *spec.Model) error {
+		rs, errs := g.Apply(m)
+		return view.RenderOn(view.Console, rs, errs)
+	}),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "file",
@@ -24,29 +25,4 @@ var applyCommand = &cli.Command{
 			Usage: "Force create, replace existing resource if exists",
 		},
 	},
-}
-
-func cmdApply(c *cli.Context) error {
-	token, err := resolveToken(c)
-	if err != nil {
-		return err
-	}
-
-	model := new(spec.Model)
-	if err := model.FromFile(c.String("file")); err != nil {
-		return err
-	}
-	debug := os.Getenv("DEBUG") != ""
-	g, err := gitstrap.New(c.Context, token, debug)
-	if err != nil {
-		return err
-	}
-	if c.Bool("force") {
-		model.Metadata.Annotations["force"] = "true"
-	}
-	rs, errs := g.Apply(model)
-	if err := view.RenderOn(view.Console, rs, errs); err != nil {
-		fatal(err)
-	}
-	return nil
 }

--- a/cmd/gitstrap/cmd_create.go
+++ b/cmd/gitstrap/cmd_create.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/g4s8/gitstrap/internal/gitstrap"
 	"github.com/g4s8/gitstrap/internal/spec"
 	"github.com/g4s8/gitstrap/internal/view"
@@ -13,7 +11,10 @@ var createCommand = &cli.Command{
 	Name:    "create",
 	Aliases: []string{"c"},
 	Usage:   "Create new resource",
-	Action:  cmdCreate,
+	Action: cmdForEachModel(func(g *gitstrap.Gitstrap, m *spec.Model) error {
+		rs, errs := g.Create(m)
+		return view.RenderOn(view.Console, rs, errs)
+	}),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "file",
@@ -25,29 +26,4 @@ var createCommand = &cli.Command{
 			Usage: "Force create, replace existing resource if exists",
 		},
 	},
-}
-
-func cmdCreate(c *cli.Context) error {
-	token, err := resolveToken(c)
-	if err != nil {
-		return err
-	}
-
-	model := new(spec.Model)
-	if err := model.FromFile(c.String("file")); err != nil {
-		return err
-	}
-	debug := os.Getenv("DEBUG") != ""
-	g, err := gitstrap.New(c.Context, token, debug)
-	if err != nil {
-		return err
-	}
-	if c.Bool("force") {
-		model.Metadata.Annotations["force"] = "true"
-	}
-	rs, errs := g.Create(model)
-	if err := view.RenderOn(view.Console, rs, errs); err != nil {
-		fatal(err)
-	}
-	return nil
 }

--- a/cmd/gitstrap/cmd_delete.go
+++ b/cmd/gitstrap/cmd_delete.go
@@ -1,22 +1,20 @@
 package main
 
 import (
-	"os"
-
 	"github.com/g4s8/gitstrap/internal/gitstrap"
 	"github.com/g4s8/gitstrap/internal/spec"
 	"github.com/g4s8/gitstrap/internal/view"
 	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"path/filepath"
 )
 
 var deleteCommand = &cli.Command{
 	Name:    "delete",
 	Aliases: []string{"remove", "del", "rm"},
 	Usage:   "Delete resource",
-	Action:  cmdDelete,
+	Action: cmdForEachModel(func(g *gitstrap.Gitstrap, m *spec.Model) error {
+		rs, errs := g.Delete(m)
+		return view.RenderOn(view.Console, rs, errs)
+	}),
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "file",
@@ -24,31 +22,4 @@ var deleteCommand = &cli.Command{
 			Usage:   "Resource specification file",
 		},
 	},
-}
-
-func cmdDelete(c *cli.Context) error {
-	token, err := resolveToken(c)
-	if err != nil {
-		return err
-	}
-
-	fn, _ := filepath.Abs(c.String("file"))
-	data, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return err
-	}
-	model := new(spec.Model)
-	if err := yaml.Unmarshal(data, model); err != nil {
-		return err
-	}
-	debug := os.Getenv("DEBUG") != ""
-	g, err := gitstrap.New(c.Context, token, debug)
-	if err != nil {
-		return err
-	}
-	rs, errs := g.Delete(model)
-	if err := view.RenderOn(view.Console, rs, errs); err != nil {
-		fatal(err)
-	}
-	return nil
 }

--- a/cmd/gitstrap/utils.go
+++ b/cmd/gitstrap/utils.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"strings"
+
+	"github.com/g4s8/gitstrap/internal/gitstrap"
+	"github.com/g4s8/gitstrap/internal/spec"
+	"github.com/urfave/cli/v2"
+)
+
+type errAggregate struct {
+	errs []error
+}
+
+func (e *errAggregate) push(err error) {
+	e.errs = append(e.errs, err)
+}
+
+func (e *errAggregate) ifAny() error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+	return e
+}
+
+func (e *errAggregate) Error() string {
+	sb := new(strings.Builder)
+	sb.WriteString("There are multiple errors occured:\n")
+	for pos, err := range e.errs {
+		sb.WriteString(fmt.Sprintf("  %d - %s\n", pos, err))
+	}
+	return sb.String()
+}
+
+type gtask func(g *gitstrap.Gitstrap, m *spec.Model) error
+
+func cmdForEachModel(task gtask) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		token, err := resolveToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		models, err := spec.ReadFile(ctx.String("file"))
+		if err != nil {
+			return err
+		}
+		debug := os.Getenv("DEBUG") != ""
+		g, err := gitstrap.New(ctx.Context, token, debug)
+		if err != nil {
+			return err
+		}
+		if ctx.Bool("force") {
+			for _, m := range models {
+				m.Metadata.Annotations["force"] = "true"
+			}
+		}
+		errs := new(errAggregate)
+		for _, m := range models {
+			if err := task(g, m); err != nil {
+				errs.push(err)
+			}
+		}
+		return errs.ifAny()
+	}
+}

--- a/internal/spec/model_reader.go
+++ b/internal/spec/model_reader.go
@@ -2,17 +2,28 @@ package spec
 
 import (
 	"bufio"
+	"errors"
 	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"path/filepath"
 )
 
+var errReadNoDocument = errors.New("Not YAML document")
+
 // FromDecoder creates model from yaml decoder
 func (m *Model) FromDecoder(d *yaml.Decoder) error {
-	if err := d.Decode(m); err != nil {
+	type Doc struct {
+		Model `yaml:"inline"`
+	}
+	doc := new(Doc)
+	if err := d.Decode(&doc); err != nil {
 		return err
 	}
+	if d == nil {
+		return errReadNoDocument
+	}
+	*m = doc.Model
 	if m.Metadata == nil {
 		m.Metadata = new(Metadata)
 	}
@@ -24,16 +35,36 @@ func (m *Model) FromReader(r io.Reader) error {
 	return m.FromDecoder(yaml.NewDecoder(r))
 }
 
-// FromFile creates model from file
-func (m *Model) FromFile(name string) error {
+// ReadFile models from file
+func ReadFile(name string) ([]*Model, error) {
 	fn, err := filepath.Abs(name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	f, err := os.Open(fn)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer f.Close()
-	return m.FromReader(bufio.NewReader(f))
+	return ReadStream(bufio.NewReader(f))
+}
+
+// ReadStream of models from reader
+func ReadStream(r io.Reader) ([]*Model, error) {
+	dec := yaml.NewDecoder(r)
+	res := make([]*Model, 0)
+	for {
+		model := new(Model)
+		err := model.FromDecoder(dec)
+		if err == nil {
+			res = append(res, model)
+		} else if errors.Is(err, errReadNoDocument) {
+			continue
+		} else if errors.Is(err, io.EOF) {
+			break
+		} else {
+			return nil, err
+		}
+	}
+	return res, nil
 }


### PR DESCRIPTION
For #52 - parse multiple models from one yaml file,
common decorator for apply, create and delete command
for working with spec models.