### PR TITLE
WebHook spec for repositories and organizations

### DIFF
--- a/internal/gitstrap/utils.go
+++ b/internal/gitstrap/utils.go
@@ -1,0 +1,11 @@
+package gitstrap
+
+import "github.com/g4s8/gitstrap/internal/spec"
+
+func (g *Gitstrap) getOwner(m *spec.Model) string {
+	owner := m.Metadata.Owner
+	if owner == "" {
+		owner = g.me
+	}
+	return owner
+}

--- a/internal/spec/hook.go
+++ b/internal/spec/hook.go
@@ -2,32 +2,53 @@ package spec
 
 import (
 	"github.com/google/go-github/v33/github"
+	"strconv"
 )
 
 type Hook struct {
-	ID          *int64   `yaml:"id,omitempty"`
 	URL         string   `yaml:"url"`
 	ContentType string   `yaml:"contentType"`
 	InsecureSsl bool     `yaml:"insecureSsl,omitempty"`
 	Secret      string   `yaml:"secret,omitempty"`
 	Events      []string `yaml:"events,omitempty"`
-	Active      bool     `yaml:"active,omitempty"`
+	Active      bool     `yaml:"active"`
+	Selector    struct {
+		Repository   string `yaml:"repository,omitempty"`
+		Organization string `yaml:"organization,omitempty"`
+	} `yaml:"selector"`
 }
 
-func (h *Hook) FromGithub(g *github.Hook) {
-	h.ID = g.ID
-	if url, has := g.Config["url"]; has {
+const (
+	hookCfgUrl         = "url"
+	hookCfgContentType = "content_type"
+	hookCfgInsecureSSL = "insecure_ssl"
+)
+
+func (h *Hook) FromGithub(g *github.Hook) error {
+	if url, has := g.Config[hookCfgUrl]; has {
 		h.URL = url.(string)
 	}
-	if ct, has := g.Config["content_type"]; has {
+	if ct, has := g.Config[hookCfgContentType]; has {
 		h.ContentType = ct.(string)
 	}
-	if issl, has := g.Config["insecure_ssl"]; has {
-		h.InsecureSsl = issl.(string) == "true"
-	}
-	if sec, has := g.Config["secret"]; has {
-		h.Secret = sec.(string)
+	if issl, has := g.Config[hookCfgInsecureSSL]; has {
+		var err error
+		h.InsecureSsl, err = strconv.ParseBool(issl.(string))
+		if err != nil {
+			return err
+		}
 	}
 	h.Events = g.Events
 	h.Active = g.GetActive()
+	return nil
+}
+
+func (h *Hook) ToGithub(g *github.Hook) error {
+	g.Config = make(map[string]interface{})
+	g.Config[hookCfgUrl] = h.URL
+	g.Config[hookCfgContentType] = h.ContentType
+	g.Config[hookCfgInsecureSSL] = strconv.FormatBool(h.InsecureSsl)
+	g.Events = h.Events
+	g.Active = &h.Active
+	return nil
 }

--- a/internal/spec/model_test.go
+++ b/internal/spec/model_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"fmt"
 	"testing"
 
 	m "github.com/g4s8/go-matchers"
@@ -51,4 +52,13 @@ func Test_marshall(t *testing.T) {
 	model.Spec = repo
 	_, err := yaml.Marshal(model)
 	assert.That("Marshal without errors", err, m.Nil())
+}
+
+func Test_validate(t *testing.T) {
+	for _, k := range []Kind{KindRepo, KindHook, KindOrg, KindReadme} {
+		t.Run(fmt.Sprintf("validate kind %s", k), func(t *testing.T) {
+			assert := m.Assert(t)
+			assert.That("no validation errors", k.validate(), m.Nil())
+		})
+	}
 }

--- a/internal/spec/readme.go
+++ b/internal/spec/readme.go
@@ -8,7 +8,6 @@ import (
 type Readme struct {
 	Selector struct {
 		Repository string `yaml:"repository"`
-		Owner      string `yaml:"owner,omitempty"`
 	} `yaml:"selector"`
 	Title    string `yaml:"title,omitempty"`
 	Abstract string `yaml:"abstract,omitempty"`


### PR DESCRIPTION
Closes #48 - added WebHook spec, implemented create, apply, get and
delete commands for webhooks. Manage both: repositories and organization
hooks, choosing by selector.