### PR TITLE
fixed bug in createRepo

### DIFF
--- a/internal/gitstrap/create.go
+++ b/internal/gitstrap/create.go
@@ -47,7 +47,8 @@ func (g *Gitstrap) createRepo(m *spec.Model) error {
 	}
 	grepo.Name = &meta.Name
 	grepo.FullName = &fn
-	r, _, err := g.gh.Repositories.Create(ctx, owner, grepo)
+	org := g.resolveOrg(m)
+	r, _, err := g.gh.Repositories.Create(ctx, org, grepo)
 	if err != nil {
 		return err
 	}

--- a/internal/gitstrap/utils.go
+++ b/internal/gitstrap/utils.go
@@ -9,3 +9,14 @@ func (g *Gitstrap) getOwner(m *spec.Model) string {
 	}
 	return owner
 }
+
+//resolveOrg determines whether the owner is an organization.
+//If the owner is the same as the authorized user, it returns an empty string.
+//Otherwise it returns owner, because githab only allows repositories
+//to be created in a personal account or in an organization the user is a member of.
+func (g *Gitstrap) resolveOrg(m *spec.Model) string {
+	if m.Metadata.Owner == g.me {
+		return ""
+	}
+	return m.Metadata.Owner
+}


### PR DESCRIPTION
Fixed #56 in Gitstrap.createRepo.

Bug caused the inability to create a personal repository. 
RepositoriesService.Create recieved the owner's name as an "org" argument, even if owner is an authorized user.

Added resolveOrg method, that determines whether the owner is an organization.
If the owner is the same as the authorized user, it returns an empty string.
Otherwise it returns owner, because GitHub only allows repositories 
to be created in a personal account or in an organization the user is a member of.

Repository creation now works properly for both personal and organisational repositories