### PR TITLE
Fixed bug in apply command

### DIFF
--- a/internal/github/org.go
+++ b/internal/github/org.go
@@ -7,12 +7,6 @@ import (
 )
 
 func OrgExist(cli *gh.Client, ctx context.Context, name string) (bool, error) {
-	_, rsp, err := cli.Organizations.Get(ctx, name)
-	if err != nil {
-		return false, err
-	}
-	if rsp.StatusCode == 404 {
-		return false, nil
-	}
-	return true, nil
+	_, _, err := cli.Organizations.Get(ctx, name)
+	return parseBoolResponse(err)
 }

--- a/internal/github/org.go
+++ b/internal/github/org.go
@@ -8,5 +8,5 @@ import (
 
 func OrgExist(cli *gh.Client, ctx context.Context, name string) (bool, error) {
 	_, _, err := cli.Organizations.Get(ctx, name)
-	return parseBoolResponse(err)
+	return resolveResponseByErr(err)
 }

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -7,12 +7,6 @@ import (
 )
 
 func RepoExist(cli *gh.Client, ctx context.Context, owner, name string) (bool, error) {
-	_, rsp, err := cli.Repositories.Get(ctx, owner, name)
-	if err != nil {
-		return false, err
-	}
-	if rsp.StatusCode == 404 {
-		return false, nil
-	}
-	return true, nil
+	_, _, err := cli.Repositories.Get(ctx, owner, name)
+	return parseBoolResponse(err)
 }

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -8,5 +8,5 @@ import (
 
 func RepoExist(cli *gh.Client, ctx context.Context, owner, name string) (bool, error) {
 	_, _, err := cli.Repositories.Get(ctx, owner, name)
-	return parseBoolResponse(err)
+	return resolveResponseByErr(err)
 }

--- a/internal/github/team.go
+++ b/internal/github/team.go
@@ -7,12 +7,6 @@ import (
 )
 
 func TeamExist(cli *gh.Client, ctx context.Context, org, slug string) (bool, error) {
-	_, rsp, err := cli.Teams.GetTeamBySlug(ctx, org, slug)
-	if err != nil {
-		return false, err
-	}
-	if rsp.StatusCode == 404 {
-		return false, nil
-	}
-	return true, nil
+	_, _, err := cli.Teams.GetTeamBySlug(ctx, org, slug)
+	return parseBoolResponse(err)
 }

--- a/internal/github/team.go
+++ b/internal/github/team.go
@@ -8,5 +8,5 @@ import (
 
 func TeamExist(cli *gh.Client, ctx context.Context, org, slug string) (bool, error) {
 	_, _, err := cli.Teams.GetTeamBySlug(ctx, org, slug)
-	return parseBoolResponse(err)
+	return resolveResponseByErr(err)
 }

--- a/internal/github/utils.go
+++ b/internal/github/utils.go
@@ -6,12 +6,14 @@ import (
 	gh "github.com/google/go-github/v33/github"
 )
 
-// parseBoolResponse determines the boolean result from a GitHub API response.
-// Several GitHub API methods return boolean responses indicated by the HTTP
+// resolveResponseByErr determines the result from a GitHub API response.
+// In some cases it is necessary to interpret the "404" response
+// as "false" condition e.g. response on get repositoty request.
+// Also several GitHub API methods return boolean responses indicated by the HTTP
 // status code in the response (true indicated by a 204, false indicated by a
 // 404). This helper function will determine that result and hide the 404
 // error if present. Any other error will be returned through as-is.
-func parseBoolResponse(err error) (bool, error) {
+func resolveResponseByErr(err error) (bool, error) {
 	if err == nil {
 		return true, nil
 	}

--- a/internal/github/utils.go
+++ b/internal/github/utils.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"net/http"
+
+	gh "github.com/google/go-github/v33/github"
+)
+
+// parseBoolResponse determines the boolean result from a GitHub API response.
+// Several GitHub API methods return boolean responses indicated by the HTTP
+// status code in the response (true indicated by a 204, false indicated by a
+// 404). This helper function will determine that result and hide the 404
+// error if present. Any other error will be returned through as-is.
+func parseBoolResponse(err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	if err, ok := err.(*gh.ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
+		// Simply false. In this one case, we do not pass the error through.
+		return false, nil
+	}
+
+	// some other real error occurred
+	return false, err
+}


### PR DESCRIPTION
Fixed #62 in Gitstrap.applyRepo

Bug caused the inability to create repo if it does not exist with apply command.

Several GitHub API methods return boolean responses indicated by the HTTP
status code in the response (true indicated by a 204, false indicated by a 404)

Github.RepositoriesService.Get method returned ErrorResponse if repo did not exist.

Fixed TeamExist, OrgExist and RepoExist fuctions: аdded utility function parseBoolResponse, that determines the response result and hides the 404 error. Any other error will be returned through as-is.