### PR TITLE
Fixed get teams command

### DIFF
--- a/internal/spec/model.go
+++ b/internal/spec/model.go
@@ -63,11 +63,9 @@ func NewModel(kind Kind) (*Model, error) {
 	if err := kind.validate(); err != nil {
 		return nil, err
 	}
-	m := new(Model)
-	m.Version = Version
-	m.Kind = kind
-	m.Metadata = new(Metadata)
-	return m, nil
+	meta := new(Metadata)
+	meta.Annotations = make(map[string]string)
+	return &Model{Version: Version, Kind: kind, Metadata: meta}, nil
 }
 
 type errUnknownKind struct {


### PR DESCRIPTION
Closes #90 - Fixed get teams command
`Metadata.Annotations` map was not initialaized when a new `Model` was created.
Therefore `Gitstrap.GetTeams` panicked on assignment to nil map.
